### PR TITLE
Fixed never ending loop

### DIFF
--- a/ndev/asr.py
+++ b/ndev/asr.py
@@ -350,7 +350,7 @@ class ASR(object):
 		print "  Audio File          %s" % filepath
 		data = file_to_play.readframes(ASR.chunk_size)
 		total_chunks = 0
-		while data != '':
+		while 100*total_chunks/total_size != 100:
 			total_chunks += len(data)
 			stdout.write("\r  Bytes Sent          %d/%d \t%d%% " % (total_chunks,total_size,100*total_chunks/total_size))
 			stdout.flush()


### PR DESCRIPTION
while loop did not end in Python 3.5.2, variable `data` was never empty